### PR TITLE
Update docs to use proper markdown for dartdocs.org

### DIFF
--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -23,7 +23,7 @@ import 'package:diff_match_patch/src/match.dart' as m;
 import 'package:diff_match_patch/src/patch.dart' as p;
 
 /**
- * Class containing the diff, match and patch methods.
+ * Class containing the [diff], [match] and [patch] methods.
  * Also contains the behaviour settings.
  */
 class DiffMatchPatch {
@@ -56,7 +56,7 @@ class DiffMatchPatch {
   /**
    * When deleting a large block of text (over ~64 characters), how close do
    * the contents have to be to match the expected contents. (0.0 = perfection,
-   * 1.0 = very loose).  Note that Match_Threshold controls how closely the
+   * 1.0 = very loose).  Note that [matchThreshold] controls how closely the
    * end points of a delete need to match.
    */
   double patchDeleteThreshold = 0.5;
@@ -69,14 +69,16 @@ class DiffMatchPatch {
   /**
    * Find the differences between two texts.  Simplifies the problem by
    * stripping any common prefix or suffix off the texts before diffing.
-   * [text1] is the old string to be diffed.
-   * [text2] is the new string to be diffed.
-   * [checklines] is an optional speedup flag.  If present and false, then don't
-   *     run a line-level diff first to identify the changed areas.
-   *     Defaults to true, which does a faster, slightly less optimal diff.
-   * [deadline] is an optional time when the diff should be complete by.  Used
-   *     internally for recursive calls.  Users should set DiffTimeout instead.
-   * Returns a List of Diff objects.
+   *
+   * * [text1] is the old string to be diffed.
+   * * [text2] is the new string to be diffed.
+   * * [checklines] is an optional speedup flag.  If false, then don't
+   *   run a line-level diff first to identify the changed areas.
+   *   Defaults to true, which does a faster, slightly less optimal diff.
+   * * [deadline] is an optional time when the diff should be complete by.  Used
+   *   internally for recursive calls.  Users should set [diffTimeout] instead.
+   *
+   * Returns a List of [Diff] objects.
    */
   List<d.Diff> diff(String text1, String text2,
                     [bool checklines = true, DateTime deadline]) {
@@ -86,6 +88,7 @@ class DiffMatchPatch {
 
   /**
    * Reduce the number of edits by eliminating semantically trivial equalities.
+   *
    * [diffs] is a List of Diff objects.
    */
   void diffCleanupSemantic(List<d.Diff> diffs) {
@@ -94,6 +97,7 @@ class DiffMatchPatch {
 
   /**
    * Reduce the number of edits by eliminating operationally trivial equalities.
+   *
    * [diffs] is a List of Diff objects.
    */
   void diffCleanupEfficiency(List<d.Diff> diffs) {
@@ -103,7 +107,9 @@ class DiffMatchPatch {
   /**
    * Compute the Levenshtein distance; the number of inserted, deleted or
    * substituted characters.
+   *
    * [diffs] is a List of Diff objects.
+   *
    * Returns the number of changes.
    */
   int diff_levenshtein(List<d.Diff> diffs) {
@@ -111,11 +117,13 @@ class DiffMatchPatch {
   }
 
   /**
-   * Locate the best instance of 'pattern' in 'text' near 'loc'.
+   * Locate the best instance of [pattern] in [text] near [loc].
    * Returns -1 if no match found.
-   * [text] is the text to search.
-   * [pattern] is the pattern to search for.
-   * [loc] is the location to search around.
+   *
+   * * [text] is the text to search.
+   * * [pattern] is the pattern to search for.
+   * * [loc] is the location to search around.
+   *
    * Returns the best match index or -1.
    */
   int match(String text, String pattern, int loc) {
@@ -126,16 +134,19 @@ class DiffMatchPatch {
   /**
    * Compute a list of patches to turn text1 into text2.
    * Use diffs if provided, otherwise compute it ourselves.
+   *
    * There are four ways to call this function, depending on what data is
    * available to the caller:
-   * Method 1:
-   * [a] = text1, [opt_b] = text2
-   * Method 2:
-   * [a] = diffs
-   * Method 3 (optimal):
-   * [a] = text1, [opt_b] = diffs
-   * Method 4 (deprecated, use method 3):
-   * [a] = text1, [opt_b] = text2, [opt_c] = diffs
+   *
+   * * Method 1:
+   *   [a] = text1, [opt_b] = text2
+   * * Method 2:
+   *   [a] = diffs
+   * * Method 3 (optimal):
+   *   [a] = text1, [opt_b] = diffs
+   * * Method 4 (deprecated, use method 3):
+   *   [a] = text1, [opt_b] = text2, [opt_c] = diffs
+   *
    * Returns a List of Patch objects.
    */
   List<p.Patch> patch(a, [opt_b, opt_c]) {
@@ -147,8 +158,10 @@ class DiffMatchPatch {
   /**
    * Merge a set of patches onto the text.  Return a patched text, as well
    * as an array of true/false values indicating which patches were applied.
-   * [patches] is a List of Patch objects
-   * [text] is the old text.
+   *
+   * * [patches] is a List of Patch objects
+   * * [text] is the old text.
+   *
    * Returns a two element List, containing the new text and a List of
    *      bool values.
    */

--- a/lib/src/diff/cleanup.dart
+++ b/lib/src/diff/cleanup.dart
@@ -29,6 +29,7 @@ RegExp _blanklineStartRegex = new RegExp(r'^\r?\n\r?\n');
 
 /**
  * Reduce the number of edits by eliminating semantically trivial equalities.
+ *
  * [diffs] is a List of Diff objects.
  */
 void cleanupSemantic(List<Diff> diffs) {
@@ -142,7 +143,9 @@ void cleanupSemantic(List<Diff> diffs) {
 /**
  * Look for single edits surrounded on both sides by equalities
  * which can be shifted sideways to align the edit to a word boundary.
+ *
  * e.g: The c<ins>at c</ins>ame. -> The <ins>cat </ins>came.
+ *
  * [diffs] is a List of Diff objects.
  */
 void cleanupSemanticLossless(List<Diff> diffs) {
@@ -261,6 +264,7 @@ void cleanupSemanticLossless(List<Diff> diffs) {
 
 /**
  * Reduce the number of edits by eliminating operationally trivial equalities.
+ *
  * [diffs] is a List of Diff objects.
  */
 void cleanupEfficiency(List<Diff> diffs, int diffEditCost) {
@@ -344,6 +348,7 @@ void cleanupEfficiency(List<Diff> diffs, int diffEditCost) {
 /**
  * Reorder and merge like edit sections.  Merge equalities.
  * Any edit section can move as long as it doesn't cross an equality.
+ *
  * [diffs] is a List of Diff objects.
  */
 void cleanupMerge(List<Diff> diffs) {

--- a/lib/src/diff/delta.dart
+++ b/lib/src/diff/delta.dart
@@ -21,11 +21,15 @@
 part of diff;
 
 /**
- * Crush the diff into an encoded string which describes the operations
+ * Crush the diff into an encoded String which describes the operations
  * required to transform text1 into text2.
+ *
  * E.g. =3\t-2\t+ing  -> Keep 3 chars, delete 2 chars, insert 'ing'.
+ *
  * Operations are tab-separated.  Inserted text is escaped using %xx notation.
+ *
  * [diffs] is a List of Diff objects.
+ *
  * Returns the delta text.
 */
 String toDelta(List<Diff> diffs) {
@@ -61,11 +65,14 @@ String toDelta(List<Diff> diffs) {
 }
 
 /**
- * Given the original text1, and an encoded string which describes the
- * operations required to transform text1 into text2, compute the full diff.
- * [text1] is the source string for the diff.
- * [delta] is the delta text.
+ * Given the original [text1], and an encoded String which describes the
+ * operations required to transform [text1] into text2, compute the full diff.
+ *
+ * * [text1] is the source string for the diff.
+ * * [delta] is the delta text.
+ *
  * Returns a List of Diff objects or null if invalid.
+ *
  * Throws ArgumentError if invalid input.
  */
 List<Diff> fromDelta(String text1, String delta) {

--- a/lib/src/diff/diff.dart
+++ b/lib/src/diff/diff.dart
@@ -22,10 +22,14 @@ part of diff;
 
 /**
  * The data structure representing a diff is a List of Diff objects:
- * {Diff(DIFF_DELETE, 'Hello'), Diff(DIFF_INSERT, 'Goodbye'),
- *  Diff(DIFF_EQUAL, ' world.')}
+ *
+ *     [Diff(DIFF_DELETE, 'Hello'),
+ *      Diff(DIFF_INSERT, 'Goodbye'),
+ *      Diff(DIFF_EQUAL, ' world.')]
+ *
  * which means: delete 'Hello', add 'Goodbye' and keep ' world.'
  */
+
 const DIFF_DELETE = -1;
 const DIFF_INSERT = 1;
 const DIFF_EQUAL = 0;
@@ -35,7 +39,7 @@ const DIFF_EQUAL = 0;
  */
 class Diff {
   /**
-   * One of: DIFF_INSERT, DIFF_DELETE or DIFF_EQUAL.
+   * One of: [DIFF_INSERT], [DIFF_DELETE] or [DIFF_EQUAL].
    */
   int operation;
   /**
@@ -45,13 +49,15 @@ class Diff {
 
   /**
    * Constructor.  Initializes the diff with the provided values.
-   * [operation] is one of DIFF_INSERT, DIFF_DELETE or DIFF_EQUAL.
-   * [text] is the text being applied.
+   *
+   * * [operation] is one of [DIFF_INSERT], [DIFF_DELETE] or [DIFF_EQUAL].
+   * * [text] is the text being applied.
    */
   Diff(this.operation, this.text);
 
   /**
    * Display a human-readable version of this Diff.
+   *
    * Returns a text version.
    */
   String toString() {
@@ -61,7 +67,9 @@ class Diff {
 
   /**
    * Is this Diff equivalent to another Diff?
+   *
    * [other] is another Diff to compare against.
+   *
    * Returns true or false.
    */
   bool operator ==(Diff other) {

--- a/lib/src/diff/half_match.dart
+++ b/lib/src/diff/half_match.dart
@@ -23,12 +23,15 @@ part of diff;
 /**
  * Do the two texts share a substring which is at least half the length of
  * the longer text?
+ *
  * This speedup can produce non-minimal diffs.
- * [text1] is the first string.
- * [text2] is the second string.
- * Returns a five element List of Strings, containing the prefix of text1,
- *     the suffix of text1, the prefix of text2, the suffix of text2 and the
- *     common middle.  Or null if there was no match.
+ *
+ * * [text1] is the first string.
+ * * [text2] is the second string.
+ *
+ * Returns a five element List of Strings, containing the prefix of [text1],
+ * the suffix of [text1], the prefix of [text2], the suffix of [text2] and the
+ * common middle.  Or null if there was no match.
  */
 List<String> diffHalfMatch(String text1, String text2, double timeout) {
   if (timeout <= 0) {
@@ -69,14 +72,16 @@ List<String> diffHalfMatch(String text1, String text2, double timeout) {
 }
 
 /**
- * Does a substring of shorttext exist within longtext such that the
- * substring is at least half the length of longtext?
- * [longtext] is the longer string.
- * [shorttext is the shorter string.
- * [i] Start index of quarter length substring within longtext.
- * Returns a five element String array, containing the prefix of longtext,
- *     the suffix of longtext, the prefix of shorttext, the suffix of
- *     shorttext and the common middle.  Or null if there was no match.
+ * Does a substring of [shorttext] exist within [longtext] such that the
+ * substring is at least half the length of [longtext]?
+ *
+ * * [longtext] is the longer string.
+ * * [shorttext is the shorter string.
+ * * [i] Start index of quarter length substring within longtext.
+ *
+ * Returns a five element String array, containing the prefix of [longtext],
+ * the suffix of [longtext], the prefix of [shorttext], the suffix of
+ * [shorttext] and the common middle.  Or null if there was no match.
  */
 List<String> _diffHalfMatchI(String longtext, String shorttext, int i) {
   // Start with a 1/4 length substring at position i as a seed.

--- a/lib/src/diff/main.dart
+++ b/lib/src/diff/main.dart
@@ -23,15 +23,17 @@ part of diff;
 /**
  * Find the differences between two texts.  Simplifies the problem by
  * stripping any common prefix or suffix off the texts before diffing.
- * [text1] is the old string to be diffed.
- * [text2] is the new string to be diffed.
- * [timeout]  is an optional number of seconds to map a diff before giving up
- *     (0 for infinity).
- * [checklines] is an optional speedup flag.  If present and false, then don't
- *     run a line-level diff first to identify the changed areas.
- *     Defaults to true, which does a faster, slightly less optimal diff.
- * [deadline] is an optional time when the diff should be complete by.  Used
- *     internally for recursive calls.  Users should set DiffTimeout instead.
+ *
+ * * [text1] is the old string to be diffed.
+ * * [text2] is the new string to be diffed.
+ * * [timeout]  is an optional number of seconds to map a diff before giving up
+ *   (0 for infinity).
+ * * [checklines] is an optional speedup flag.  If false, then don't
+ *   run a line-level diff first to identify the changed areas.
+ *   Defaults to true, which does a faster, slightly less optimal diff.
+ * * [deadline] is an optional time when the diff should be complete by.  Used
+ *   internally for recursive calls.  Users should set [diffTimeout] instead.
+ *
  * Returns a List of Diff objects.
  */
 List<Diff> diff(String text1, String text2,
@@ -93,14 +95,16 @@ List<Diff> diff(String text1, String text2,
 /**
  * Find the differences between two texts.  Assumes that the texts do not
  * have any common prefix or suffix.
- * [text1] is the old string to be diffed.
- * [text2] is the new string to be diffed.
- * [timeout]  is a number of seconds to map a diff before giving up
- *     (0 for infinity).
- * [checklines] is a speedup flag.  If false, then don't run a
- *     line-level diff first to identify the changed areas.
- *     If true, then run a faster slightly less optimal diff.
- * [deadline] is the time when the diff should be complete by.
+ *
+ * * [text1] is the old string to be diffed.
+ * * [text2] is the new string to be diffed.
+ * * [timeout]  is a number of seconds to map a diff before giving up
+ *   (0 for infinity).
+ * * [checklines] is a speedup flag.  If false, then don't run a
+ *   line-level diff first to identify the changed areas.
+ *   If true, then run a faster slightly less optimal diff.
+ * * [deadline] is the time when the diff should be complete by.
+ *
  * Returns a List of Diff objects.
  */
 List<Diff> _diffCompute(String text1, String text2,
@@ -177,11 +181,13 @@ List<Diff> _diffCompute(String text1, String text2,
  * Do a quick line-level diff on both strings, then rediff the parts for
  * greater accuracy.
  * This speedup can produce non-minimal diffs.
- * [text1] is the old string to be diffed.
- * [text2] is the new string to be diffed.
- * [timeout]  is a number of seconds to map a diff before giving up
- *     (0 for infinity).
- * [deadline] is the time when the diff should be complete by.
+ *
+ * * [text1] is the old string to be diffed.
+ * * [text2] is the new string to be diffed.
+ * * [timeout]  is a number of seconds to map a diff before giving up
+ *   (0 for infinity).
+ * * [deadline] is the time when the diff should be complete by.
+ *
  * Returns a List of Diff objects.
  */
 List<Diff> _diffLineMode(String text1, String text2, double timeout,
@@ -251,12 +257,15 @@ List<Diff> _diffLineMode(String text1, String text2, double timeout,
 /**
  * Find the 'middle snake' of a diff, split the problem in two
  * and return the recursively constructed diff.
+ *
  * See Myers 1986 paper: An O(ND) Difference Algorithm and Its Variations.
- * [text1] is the old string to be diffed.
- * [text2] is the new string to be diffed.
- * [timeout]  is a number of seconds to map a diff before giving up
- *     (0 for infinity).
- * [deadline] is the time at which to bail if not yet complete.
+ *
+ * * [text1] is the old string to be diffed.
+ * * [text2] is the new string to be diffed.
+ * * [timeout]  is a number of seconds to map a diff before giving up
+ *   (0 for infinity).
+ * * [deadline] is the time at which to bail if not yet complete.
+ *
  * Returns a List of Diff objects.
  */
 List<Diff> diffBisect(String text1, String text2, double timeout,
@@ -372,13 +381,15 @@ List<Diff> diffBisect(String text1, String text2, double timeout,
 /**
  * Given the location of the 'middle snake', split the diff in two parts
  * and recurse.
- * [text1] is the old string to be diffed.
- * [text2] is the new string to be diffed.
- * [x] is the index of split point in text1.
- * [y] is the index of split point in text2.
- * [timeout]  is a number of seconds to map a diff before giving up
- *     (0 for infinity).
- * [deadline] is the time at which to bail if not yet complete.
+ *
+ * * [text1] is the old string to be diffed.
+ * * [text2] is the new string to be diffed.
+ * * [x] is the index of split point in text1.
+ * * [y] is the index of split point in text2.
+ * * [timeout] is a number of seconds to map a diff before giving up
+ *   (0 for infinity).
+ * * [deadline] is the time at which to bail if not yet complete.
+ *
  * Returns a List of Diff objects.
  */
 List<Diff> _diffBisectSplit(String text1, String text2,

--- a/lib/src/diff/utils.dart
+++ b/lib/src/diff/utils.dart
@@ -23,9 +23,11 @@ part of diff;
 /**
  * Split a text into a list of strings.  Reduce the texts to a string of
  * hashes where each Unicode character represents one line.
- * [text] is the string to encode.
- * [lineArray] is a List of unique strings.
- * [lineHash] is a Map of strings to indices.
+ *
+ * * [text] is the string to encode.
+ * * [lineArray] is a List of unique strings.
+ * * [lineHash] is a Map of strings to indices.
+ *
  * Returns an encoded string.
  */
 String _linesToCharsMunge(String text, List<String> lineArray,
@@ -59,11 +61,13 @@ String _linesToCharsMunge(String text, List<String> lineArray,
 /**
  * Split two texts into a list of strings.  Reduce the texts to a string of
  * hashes where each Unicode character represents one line.
- * [text1] is the first string.
- * [text2] is the second string.
- * Returns a Map containing the encoded text1, the encoded text2 and
- *     the List of unique strings.  The zeroth element of the List of
- *     unique strings is intentionally blank.
+ *
+ * * [text1] is the first string.
+ * * [text2] is the second string.
+ *
+ * Returns a Map containing the encoded [text1], the encoded [text2] and
+ * the List of unique strings.  The zeroth element of the List of
+ * unique strings is intentionally blank.
  */
 Map<String, dynamic> linesToChars(String text1, String text2) {
   final lineArray = <String>[];
@@ -83,8 +87,9 @@ Map<String, dynamic> linesToChars(String text1, String text2) {
 /**
  * Rehydrate the text in a diff from a string of line hashes to real lines of
  * text.
- * [diffs] is a List of Diff objects.
- * [lineArray] is a List of unique strings.
+ *
+ * * [diffs] is a List of Diff objects.
+ * * [lineArray] is a List of unique strings.
  */
 void charsToLines(List<Diff> diffs, List<String> lineArray) {
   final text = new StringBuffer();
@@ -99,8 +104,10 @@ void charsToLines(List<Diff> diffs, List<String> lineArray) {
 
 /**
  * Determine the common prefix of two strings
- * [text1] is the first string.
- * [text2] is the second string.
+ *
+ * * [text1] is the first string.
+ * * [text2] is the second string.
+ *
  * Returns the number of characters common to the start of each string.
  */
 int commonPrefix(String text1, String text2) {
@@ -118,8 +125,10 @@ int commonPrefix(String text1, String text2) {
 
 /**
  * Determine the common suffix of two strings
- * [text1] is the first string.
- * [text2] is the second string.
+ *
+ * * [text1] is the first string.
+ * * [text2] is the second string.
+ *
  * Returns the number of characters common to the end of each string.
  */
 int commonSuffix(String text1, String text2) {
@@ -139,10 +148,12 @@ int commonSuffix(String text1, String text2) {
 
 /**
  * Determine if the suffix of one string is the prefix of another.
- * [text1] is the first string.
- * [text2] is the second string.
+ *
+ * * [text1] is the first string.
+ * * [text2] is the second string.
+ *
  * Returns the number of characters common to the end of the first
- *     string and the start of the second string.
+ * string and the start of the second string.
  */
  int commonOverlap(String text1, String text2) {
   // Eliminate the null case.
@@ -187,7 +198,9 @@ int commonSuffix(String text1, String text2) {
 /**
  * Compute the Levenshtein distance; the number of inserted, deleted or
  * substituted characters.
+ *
  * [diffs] is a List of Diff objects.
+ *
  * Returns the number of changes.
  */
 int levenshtein(List<Diff> diffs) {
@@ -215,11 +228,14 @@ int levenshtein(List<Diff> diffs) {
 }
 
 /**
- * loc is a location in text1, compute and return the equivalent location in
+ * [loc] is a location in text1, compute and return the equivalent location in
  * text2.
+ *
  * e.g. "The cat" vs "The big cat", 1->1, 5->8
- * [diffs] is a List of Diff objects.
- * [loc] is the location within text1.
+ *
+ * * [diffs] is a List of Diff objects.
+ * * [loc] is the location within text1.
+ *
  * Returns the location within text2.
  */
 int diffXIndex(List<Diff> diffs, int loc) {
@@ -255,7 +271,9 @@ int diffXIndex(List<Diff> diffs, int loc) {
 
 /**
  * Compute and return the source text (all equalities and deletions).
+ *
  * [diffs] is a List of Diff objects.
+ *
  * Returns the source text.
  */
 String diffText1(List<Diff> diffs) {
@@ -270,7 +288,9 @@ String diffText1(List<Diff> diffs) {
 
 /**
  * Compute and return the destination text (all equalities and insertions).
+ *
  * [diffs] is a List of Diff objects.
+ *
  * Returns the destination text.
  */
 String diffText2(List<Diff> diffs) {

--- a/lib/src/match.dart
+++ b/lib/src/match.dart
@@ -23,16 +23,18 @@ import 'dart:math';
 import 'package:diff_match_patch/src/common.dart';
 
 /**
- * Locate the best instance of 'pattern' in 'text' near 'loc'.
+ * Locate the best instance of [pattern] in [text] near [loc].
  * Returns -1 if no match found.
- * [text] is the text to search.
- * [pattern] is the pattern to search for.
- * [loc] is the location to search around.
- * [threshold] At what point is no match declared (0.0 = perfection,
- *     1.0 = very loose).
- * [distance] How far to search for a match (0 = exact location, 1000+ = broad
- *     match). A match this many characters away from the expected location will
- *     add 1.0 to the score (0.0 is a perfect match).
+ *
+ * * [text] is the text to search.
+ * * [pattern] is the pattern to search for.
+ * * [loc] is the location to search around.
+ * * [threshold] At what point is no match declared (0.0 = perfection,
+ *   1.0 = very loose).
+ * * [distance] How far to search for a match (0 = exact location, 1000+ = broad
+ *   match). A match this many characters away from the expected location will
+ *   add 1.0 to the score (0.0 is a perfect match).
+ *
  * Returns the best match index or -1.
  */
 int match(String text, String pattern, int loc,
@@ -60,14 +62,16 @@ int match(String text, String pattern, int loc,
 }
 
 /**
- * Compute and return the score for a match with e errors and x location.
- * [e] is the number of errors in match.
- * [x] is the location of match.
- * [loc] is the expected location of match.
- * [pattern] is the pattern being sought.
- * [distance] How far to search for a match (0 = exact location, 1000+ = broad
- *     match). A match this many characters away from the expected location will
- *     add 1.0 to the score (0.0 is a perfect match).
+ * Compute and return the score for a match with [e] errors and [x] location.
+ *
+ * * [e] is the number of errors in match.
+ * * [x] is the location of match.
+ * * [loc] is the expected location of match.
+ * * [pattern] is the pattern being sought.
+ * * [distance] How far to search for a match (0 = exact location, 1000+ = broad
+ *   match). A match this many characters away from the expected location will
+ *   add 1.0 to the score (0.0 is a perfect match).
+ *
  * Returns the overall score for match (0.0 = good, 1.0 = bad).
  */
 double _bitapScore(int e, int x, int loc, String pattern, int distance) {
@@ -81,16 +85,18 @@ double _bitapScore(int e, int x, int loc, String pattern, int distance) {
 }
 
 /**
- * Locate the best instance of 'pattern' in 'text' near 'loc' using the
+ * Locate the best instance of [pattern] in [text] near [loc] using the
  * Bitap algorithm.  Returns -1 if no match found.
- * [text] is the the text to search.
- * [pattern] is the pattern to search for.
- * [loc] is the location to search around.
- * [threshold] At what point is no match declared (0.0 = perfection,
- *     1.0 = very loose).
- * [distance] How far to search for a match (0 = exact location, 1000+ = broad
- *     match). A match this many characters away from the expected location will
- *     add 1.0 to the score (0.0 is a perfect match).
+ *
+ * * [text] is the the text to search.
+ * * [pattern] is the pattern to search for.
+ * * [loc] is the location to search around.
+ * * [threshold] At what point is no match declared (0.0 = perfection,
+ *   1.0 = very loose).
+ * * [distance] How far to search for a match (0 = exact location, 1000+ = broad
+ *   match). A match this many characters away from the expected location will
+ *   add 1.0 to the score (0.0 is a perfect match).
+ *
  * Returns the best match index or -1.
  */
 int matchBitap(String text, String pattern, int loc, double threshold,
@@ -190,6 +196,7 @@ int matchBitap(String text, String pattern, int loc, double threshold,
 
 /**
  * Initialise the alphabet for the Bitap algorithm.
+ *
  * [pattern] is the the text to encode.
  * Returns a Map of character locations.
  */

--- a/lib/src/patch.dart
+++ b/lib/src/patch.dart
@@ -43,7 +43,9 @@ class Patch {
 
   /**
    * Emmulate GNU diff's format.
+   *
    * Header: @@ -382,8 +481,9 @@
+   *
    * Indicies are printed as 1-based, not 0-based.
    * Returns the GNU diff string.
    */
@@ -87,6 +89,7 @@ class Patch {
 
 /**
  * Take a list of patches and return a textual representation.
+ *
  * [patches] is a List of Patch objects.
  * Returns a text representation of patches.
  */
@@ -99,10 +102,12 @@ String patchToText(List<Patch> patches) {
 }
 
 /**
- * Parse a textual representation of patches and return a List of Patch
- * objects.
+ * Parse a textual representation of patches and return a List of Patch objects.
+ *
  * [textline] is a text representation of patches.
+ *
  * Returns a List of Patch objects.
+ *
  * Throws ArgumentError if invalid input.
  */
 List<Patch> patchFromText(String textline) {
@@ -183,9 +188,10 @@ List<Patch> patchFromText(String textline) {
 /**
  * Increase the context until it is unique,
  * but don't let the pattern expand beyond Match_MaxBits.
- * [patch] is the phe patch to grow.
- * [text] is the source text.
- * [patchMargin] Chunk size for context length.
+ *
+ * * [patch] is the patch to grow.
+ * * [text] is the source text.
+ * * [patchMargin] Chunk size for context length.
  */
 void patchAddContext(Patch patch, String text, int patchMargin) {
   if (text.isEmpty) {
@@ -226,18 +232,21 @@ void patchAddContext(Patch patch, String text, int patchMargin) {
 }
 
 /**
- * Compute a list of patches to turn text1 into text2.
+ * Compute a List of Patches to turn [text1] into [text2].
+ *
  * Use diffs if provided, otherwise compute it ourselves.
  * There are four ways to call this function, depending on what data is
  * available to the caller:
- * Method 1:
- * [a] = text1, [b] = text2
- * Method 2:
- * [a] = diffs
- * Method 3 (optimal):
- * [a] = text1, [b] = diffs
- * Method 4 (deprecated, use method 3):
- * [a] = text1, [b] = text2, [c] = diffs
+ *
+ * * Method 1:
+ *   [a] = text1, [b] = text2
+ * * Method 2:
+ *   [a] = diffs
+ * * Method 3 (optimal):
+ *   [a] = text1, [b] = diffs
+ * * Method 4 (deprecated, use method 3):
+ *   [a] = text1, [b] = text2, [c] = diffs
+ *
  * Returns a List of Patch objects.
  */
 List<Patch> patchMake(a, {b, c, double diffTimeout: 1.0, DateTime diffDeadline,
@@ -378,12 +387,15 @@ List<Patch> patchDeepCopy(List<Patch> patches) {
 }
 
 /**
- * Merge a set of patches onto the text.  Return a patched text, as well
+ * Merge a set of patches onto the text.
+ *
+ * Return a patched text, as well
  * as an array of true/false values indicating which patches were applied.
- * [patches] is a List of Patch objects
- * [text] is the old text.
- * Returns a two element List, containing the new text and a List of
- *      bool values.
+ *
+ * * [patches] is a List of Patch objects
+ * * [text] is the old text.
+ *
+ * Returns a two element List, containing the new text and a List of bool values.
  */
 List patchApply(List<Patch> patches, String text,
                 {double deleteThreshold: 0.5, double diffTimeout: 1.0,
@@ -506,8 +518,11 @@ List patchApply(List<Patch> patches, String text,
 
 /**
  * Add some padding on text start and end so that edges can match something.
- * Intended to be called only from within patch_apply.
+ *
+ * Intended to be called only from within [patch_apply].
+ *
  * [patches] is a List of Patch objects.
+ *
  * Returns the padding string added to each side.
  */
 String patchAddPadding(List<Patch> patches, {int margin: 4}) {
@@ -568,9 +583,11 @@ String patchAddPadding(List<Patch> patches, {int margin: 4}) {
 }
 
 /**
- * Look through the patches and break up any which are longer than the
+ * Look through the [patches] and break up any which are longer than the
  * maximum limit of the match algorithm.
- * Intended to be called only from within patch_apply.
+ *
+ * Intended to be called only from within [patch_apply].
+ *
  * [patches] is a List of Patch objects.
  */
 void patchSplitMax(List<Patch> patches, {int margin: 4}) {


### PR DESCRIPTION
Hi @localvoid, I found your excellent library and intend to use it in a project of my own.

However, the docs at [dartdocs.org](http://www.dartdocs.org/documentation/diff_match_patch/0.2.0/index.html#diff_match_patch/diff_match_patch) are broken because the documentation comments are parsed as Markdown, and so the formatting is all broken (see diff() and match() for particularly bad examples). This PR fixes it, and makes (almost) no text content changes.

Let me know if there is anything you dislike. Thanks!
